### PR TITLE
allow dynamic imports for react-native

### DIFF
--- a/scripts/index-files.js
+++ b/scripts/index-files.js
@@ -7,8 +7,31 @@ const json = new Files(Files.configs.json)
 const files = new Files()
 
 json.write('utils', {
-  dest: ({ cwd }) => `${cwd}/utils/packages.json`,
-  content: (folders) => JSON.stringify(folders.filter((folder) => folder !== 'utils'), null, 2),
+  banner: Files.configs.exports.banner,
+  dest: ({ cwd }) => `${cwd}/utils/src/packages.mjs`,
+  content: (_) => {
+    const pkgs = _
+      .filter((folder) => ![ 'utils', 'files' ].includes(folder))
+      .map((folder) => {
+        return Files.normalize(`
+          try {
+            const pkg = require('@ma-shop/${folder}')
+            if (pkg) {
+              Object.assign(module.exports, pkg)
+            }
+          } catch (e) { }
+        `)
+      })
+      .join('\n\n')
+
+    const header = Files.normalize(`
+      // is this stupid to do. Yes. But unfortuantly you have to require packages
+      // specifically, you can't use any variables in a require function in react-native
+      /* eslint-disable global-require, no-empty, import/no-extraneous-dependencies */
+    `)
+
+    return `${header}\n\n${pkgs}`
+  },
 })
 
 files.write([ 'utils/*/src' ])

--- a/utils/react-native/package.json
+++ b/utils/react-native/package.json
@@ -2,6 +2,9 @@
   "name": "@ma-shop/react-native",
   "version": "0.0.15",
   "main": "dist/index.js",
+  "scripts": {
+    "postinstall": "node ./post-install.js"
+  },
   "author": "Tyler Benton",
   "license": "MIT",
   "publishConfig": {
@@ -9,10 +12,10 @@
   },
   "gitHead": "3e213cdf455e3ac36b88a85e1f7c43d1936fe50d",
   "peerDependencies": {
-    "@ma-shop/is": "0.0.8",
-    "@ma-shop/utils": "0.0.8",
-    "react": "16.12.0",
-    "react-native": "0.61.5"
+    "@ma-shop/is": "*",
+    "@ma-shop/utils": "*",
+    "react": "*",
+    "react-native": "*"
   },
   "devDependencies": {
     "@ma-shop/is": "^0.0.11",

--- a/utils/react-native/post-install.js
+++ b/utils/react-native/post-install.js
@@ -1,0 +1,23 @@
+const fs = require('fs').promises
+
+
+async function run () {
+  const basePath = `${process.cwd()}/node_modules/@ma-shop`
+  const packagesPath = `${basePath}/utils/dist/packages.js`
+  const file = `${await fs.readFile(packagesPath).catch(() => '')}`
+  const packages = await fs.readdir(basePath).catch(() => [])
+
+  if (file && packages.length) {
+    const splitter = 'try {\n'
+    const filteredPackages = file
+      .split(splitter)
+      .filter((str) => !str.includes('@ma-shop') || packages.find((pkg) => str.includes(pkg)))
+      .join(splitter)
+
+    if (filteredPackages) {
+      await fs.writeFile(packagesPath, filteredPackages)
+    }
+  }
+}
+
+run()

--- a/utils/utils/package.json
+++ b/utils/utils/package.json
@@ -8,12 +8,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@ma-shop/apollo": "^0.0.11",
-    "@ma-shop/files": "^0.0.11",
-    "@ma-shop/is": "^0.0.11",
-    "@ma-shop/locale": "^0.0.14",
-    "@ma-shop/react": "^0.0.11",
-    "@ma-shop/react-native": "^0.0.15",
     "lodash": "4.17.15"
   },
   "gitHead": "3e213cdf455e3ac36b88a85e1f7c43d1936fe50d"

--- a/utils/utils/src/packages.mjs
+++ b/utils/utils/src/packages.mjs
@@ -1,34 +1,42 @@
-/* eslint-disable global-require, import/no-dynamic-require  */
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!! This file is generated do not modify it manually because it will be overwritten
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-import pkgs from '../packages.json'
+// is this stupid to do. Yes. But unfortuantly you have to require packages
+// specifically, you can't use any variables in a require function in react-native
+/* eslint-disable global-require, no-empty, import/no-extraneous-dependencies */
 
-
-// @todo uninstall all these packages when react-native metro bundler doesn't suck and allows
-// you to import packages dynamically. But for now all these packages have to be installed.
-// https://github.com/facebook/metro/pull/511
-
-function stupidWorkAroundForReactNative (pkg) {
-  switch (pkg) {
-    case '@ma-shop/is': return require('@ma-shop/is')
-    case '@ma-shop/locale': return require('@ma-shop/locale')
-    case '@ma-shop/react': return require('@ma-shop/react')
-    case '@ma-shop/react-native': return require('@ma-shop/react-native')
-    case '@ma-shop/apollo': return require('@ma-shop/apollo')
-    // @note this can't be required because it uses the built in `fs` library
-    // case '@ma-shop/files': return require('@ma-shop/files')
-    default:
+try {
+  const pkg = require('@ma-shop/apollo')
+  if (pkg) {
+    Object.assign(module.exports, pkg)
   }
-}
+} catch (e) { }
 
-pkgs
-  .map((pkg) => `@ma-shop/${pkg}`)
-  .forEach((_) => {
-    try {
-      const pkg = stupidWorkAroundForReactNative(_)
-      if (pkg) {
-        Object.assign(module.exports, pkg)
-      }
-    } catch (e) {
-      console.log(`error trying to import ${_}`, e)
-    }
-  })
+try {
+  const pkg = require('@ma-shop/is')
+  if (pkg) {
+    Object.assign(module.exports, pkg)
+  }
+} catch (e) { }
+
+try {
+  const pkg = require('@ma-shop/locale')
+  if (pkg) {
+    Object.assign(module.exports, pkg)
+  }
+} catch (e) { }
+
+try {
+  const pkg = require('@ma-shop/react')
+  if (pkg) {
+    Object.assign(module.exports, pkg)
+  }
+} catch (e) { }
+
+try {
+  const pkg = require('@ma-shop/react-native')
+  if (pkg) {
+    Object.assign(module.exports, pkg)
+  }
+} catch (e) { }


### PR DESCRIPTION
since react-native can't handle this stuff correctly this handles it for them by only leaving the packages that are actually there.


Since this is meant to only run on post install you can't really test this by just installing it since this has to be released before it can work. But you can fake it by following these steps.

- make index-files
- make build
- replace line 5 in `post-install.js` with this
```js
const basePath = `${__dirname}/..`
```
- modify `uitls/dist/packages.js` and add this fake package a few times and save the changes
```
try {
  var _pkg = require('@ma-shop/woohoo');

  if (_pkg) {
    (0, _extends2.default)(module.exports, _pkg);
  }
} catch (e) {}
```
- next run the following command and confirm that the fake packages you just added aren't there anymore.
```
node ./utils/react-native/post-install.js
```

